### PR TITLE
Add Timesheet/Time Log API

### DIFF
--- a/backend/src/application/services/mod.rs
+++ b/backend/src/application/services/mod.rs
@@ -3,9 +3,11 @@ mod auth_app_service;
 mod project_app_service;
 mod task_app_service;
 mod team_app_service;
+mod time_log_app_service;
 
 pub use activity_app_service::ActivityAppService;
 pub use auth_app_service::{AuthAppService, AuthResponse, Claims};
 pub use project_app_service::ProjectAppService;
 pub use task_app_service::TaskAppService;
 pub use team_app_service::TeamAppService;
+pub use time_log_app_service::{TimeLogAppService, CreateTimeLogDto, UpdateTimeLogDto};

--- a/backend/src/application/services/time_log_app_service.rs
+++ b/backend/src/application/services/time_log_app_service.rs
@@ -1,0 +1,109 @@
+use std::sync::Arc;
+use chrono::{NaiveDate, Utc};
+use uuid::Uuid;
+
+use crate::domain::entities::TimeLog;
+use crate::domain::repositories::TimeLogRepository;
+use crate::shared::DomainError;
+
+#[derive(Debug)]
+pub struct CreateTimeLogDto {
+    pub task_id: Uuid,
+    pub user_id: Uuid,
+    pub hours: f32,
+    pub date: NaiveDate,
+    pub description: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct UpdateTimeLogDto {
+    pub hours: Option<f32>,
+    pub date: Option<NaiveDate>,
+    pub description: Option<String>,
+}
+
+pub struct TimeLogAppService {
+    time_log_repository: Arc<dyn TimeLogRepository>,
+}
+
+impl TimeLogAppService {
+    pub fn new(time_log_repository: Arc<dyn TimeLogRepository>) -> Self {
+        Self { time_log_repository }
+    }
+
+    pub async fn get_time_log(&self, id: Uuid) -> Result<Option<TimeLog>, DomainError> {
+        self.time_log_repository.find_by_id(id).await
+    }
+
+    pub async fn get_user_time_logs(
+        &self,
+        user_id: Uuid,
+        start_date: Option<NaiveDate>,
+        end_date: Option<NaiveDate>,
+    ) -> Result<Vec<TimeLog>, DomainError> {
+        self.time_log_repository.find_by_user(user_id, start_date, end_date).await
+    }
+
+    pub async fn get_task_time_logs(&self, task_id: Uuid) -> Result<Vec<TimeLog>, DomainError> {
+        self.time_log_repository.find_by_task(task_id).await
+    }
+
+    pub async fn get_time_logs_by_date_range(
+        &self,
+        user_id: Uuid,
+        start_date: NaiveDate,
+        end_date: NaiveDate,
+    ) -> Result<Vec<TimeLog>, DomainError> {
+        self.time_log_repository.find_by_date_range(user_id, start_date, end_date).await
+    }
+
+    pub async fn create_time_log(&self, dto: CreateTimeLogDto) -> Result<TimeLog, DomainError> {
+        let now = Utc::now();
+        let time_log = TimeLog {
+            id: Uuid::new_v4(),
+            task_id: dto.task_id,
+            user_id: dto.user_id,
+            hours: dto.hours,
+            date: dto.date,
+            description: dto.description,
+            created_at: now,
+            updated_at: now,
+            task_name: None,
+            project_name: None,
+            user_name: None,
+        };
+
+        self.time_log_repository.create(&time_log).await
+    }
+
+    pub async fn update_time_log(
+        &self,
+        id: Uuid,
+        dto: UpdateTimeLogDto,
+    ) -> Result<TimeLog, DomainError> {
+        let existing = self.time_log_repository
+            .find_by_id(id)
+            .await?
+            .ok_or_else(|| DomainError::NotFound(format!("Time log with id {} not found", id)))?;
+
+        let updated = TimeLog {
+            hours: dto.hours.unwrap_or(existing.hours),
+            date: dto.date.unwrap_or(existing.date),
+            description: dto.description.or(existing.description),
+            updated_at: Utc::now(),
+            ..existing
+        };
+
+        self.time_log_repository.update(&updated).await
+    }
+
+    pub async fn delete_time_log(&self, id: Uuid) -> Result<(), DomainError> {
+        // Check if exists
+        self.time_log_repository
+            .find_by_id(id)
+            .await?
+            .ok_or_else(|| DomainError::NotFound(format!("Time log with id {} not found", id)))?;
+
+        self.time_log_repository.delete(id).await
+    }
+}

--- a/backend/src/domain/entities/mod.rs
+++ b/backend/src/domain/entities/mod.rs
@@ -3,6 +3,7 @@ mod milestone;
 mod project;
 mod task;
 mod team;
+mod time_log;
 mod user;
 
 pub use activity_log::{ActivityAction, ActivityLog, EntityType};
@@ -10,4 +11,5 @@ pub use milestone::Milestone;
 pub use project::{Project, ProjectMember};
 pub use task::{Task, TaskComment};
 pub use team::{Team, TeamMember};
+pub use time_log::TimeLog;
 pub use user::User;

--- a/backend/src/domain/entities/time_log.rs
+++ b/backend/src/domain/entities/time_log.rs
@@ -1,0 +1,47 @@
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimeLog {
+    pub id: Uuid,
+    pub task_id: Uuid,
+    pub user_id: Uuid,
+    pub hours: f32,
+    pub date: NaiveDate,
+    pub description: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    // Joined fields (populated from queries)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_name: Option<String>,
+}
+
+impl TimeLog {
+    pub fn new(
+        task_id: Uuid,
+        user_id: Uuid,
+        hours: f32,
+        date: NaiveDate,
+        description: Option<String>,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::new_v4(),
+            task_id,
+            user_id,
+            hours,
+            date,
+            description,
+            created_at: now,
+            updated_at: now,
+            task_name: None,
+            project_name: None,
+            user_name: None,
+        }
+    }
+}

--- a/backend/src/domain/repositories/mod.rs
+++ b/backend/src/domain/repositories/mod.rs
@@ -2,10 +2,12 @@ mod activity_log_repository;
 mod project_repository;
 mod task_repository;
 mod team_repository;
+mod time_log_repository;
 mod user_repository;
 
 pub use activity_log_repository::ActivityLogRepository;
 pub use project_repository::ProjectRepository;
 pub use task_repository::TaskRepository;
 pub use team_repository::TeamRepository;
+pub use time_log_repository::TimeLogRepository;
 pub use user_repository::UserRepository;

--- a/backend/src/domain/repositories/time_log_repository.rs
+++ b/backend/src/domain/repositories/time_log_repository.rs
@@ -1,0 +1,17 @@
+use async_trait::async_trait;
+use chrono::NaiveDate;
+use uuid::Uuid;
+
+use crate::domain::entities::TimeLog;
+use crate::shared::DomainError;
+
+#[async_trait]
+pub trait TimeLogRepository: Send + Sync {
+    async fn find_by_id(&self, id: Uuid) -> Result<Option<TimeLog>, DomainError>;
+    async fn find_by_user(&self, user_id: Uuid, start_date: Option<NaiveDate>, end_date: Option<NaiveDate>) -> Result<Vec<TimeLog>, DomainError>;
+    async fn find_by_task(&self, task_id: Uuid) -> Result<Vec<TimeLog>, DomainError>;
+    async fn find_by_date_range(&self, user_id: Uuid, start_date: NaiveDate, end_date: NaiveDate) -> Result<Vec<TimeLog>, DomainError>;
+    async fn create(&self, time_log: &TimeLog) -> Result<TimeLog, DomainError>;
+    async fn update(&self, time_log: &TimeLog) -> Result<TimeLog, DomainError>;
+    async fn delete(&self, id: Uuid) -> Result<(), DomainError>;
+}

--- a/backend/src/infrastructure/persistence/mod.rs
+++ b/backend/src/infrastructure/persistence/mod.rs
@@ -2,10 +2,12 @@ mod pg_activity_log_repository;
 mod pg_project_repository;
 mod pg_task_repository;
 mod pg_team_repository;
+mod pg_time_log_repository;
 mod pg_user_repository;
 
 pub use pg_activity_log_repository::PgActivityLogRepository;
 pub use pg_project_repository::PgProjectRepository;
 pub use pg_task_repository::PgTaskRepository;
 pub use pg_team_repository::PgTeamRepository;
+pub use pg_time_log_repository::PgTimeLogRepository;
 pub use pg_user_repository::PgUserRepository;

--- a/backend/src/infrastructure/persistence/pg_time_log_repository.rs
+++ b/backend/src/infrastructure/persistence/pg_time_log_repository.rs
@@ -1,0 +1,230 @@
+use async_trait::async_trait;
+use chrono::{DateTime, NaiveDate, Utc};
+use sqlx::{FromRow, PgPool};
+use uuid::Uuid;
+
+use crate::domain::entities::TimeLog;
+use crate::domain::repositories::TimeLogRepository;
+use crate::shared::DomainError;
+
+#[derive(Debug, FromRow)]
+struct TimeLogRow {
+    id: Uuid,
+    task_id: Uuid,
+    user_id: Uuid,
+    hours: f32,
+    date: NaiveDate,
+    description: Option<String>,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+    task_name: Option<String>,
+    project_name: Option<String>,
+    user_name: Option<String>,
+}
+
+impl From<TimeLogRow> for TimeLog {
+    fn from(row: TimeLogRow) -> Self {
+        TimeLog {
+            id: row.id,
+            task_id: row.task_id,
+            user_id: row.user_id,
+            hours: row.hours,
+            date: row.date,
+            description: row.description,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            task_name: row.task_name,
+            project_name: row.project_name,
+            user_name: row.user_name,
+        }
+    }
+}
+
+pub struct PgTimeLogRepository {
+    pool: PgPool,
+}
+
+impl PgTimeLogRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    fn base_query() -> &'static str {
+        r#"
+        SELECT
+            tl.id,
+            tl.task_id,
+            tl.user_id,
+            tl.hours,
+            tl.date,
+            tl.description,
+            tl.created_at,
+            tl.updated_at,
+            t.title as task_name,
+            p.name as project_name,
+            u.name as user_name
+        FROM time_logs tl
+        JOIN tasks t ON tl.task_id = t.id
+        JOIN projects p ON t.project_id = p.id
+        JOIN users u ON tl.user_id = u.id
+        "#
+    }
+}
+
+#[async_trait]
+impl TimeLogRepository for PgTimeLogRepository {
+    async fn find_by_id(&self, id: Uuid) -> Result<Option<TimeLog>, DomainError> {
+        let query = format!("{} WHERE tl.id = $1", Self::base_query());
+        let row = sqlx::query_as::<_, TimeLogRow>(&query)
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?;
+
+        Ok(row.map(Into::into))
+    }
+
+    async fn find_by_user(
+        &self,
+        user_id: Uuid,
+        start_date: Option<NaiveDate>,
+        end_date: Option<NaiveDate>,
+    ) -> Result<Vec<TimeLog>, DomainError> {
+        let query = match (start_date, end_date) {
+            (Some(_), Some(_)) => format!(
+                "{} WHERE tl.user_id = $1 AND tl.date >= $2 AND tl.date <= $3 ORDER BY tl.date DESC, tl.created_at DESC",
+                Self::base_query()
+            ),
+            (Some(_), None) => format!(
+                "{} WHERE tl.user_id = $1 AND tl.date >= $2 ORDER BY tl.date DESC, tl.created_at DESC",
+                Self::base_query()
+            ),
+            (None, Some(_)) => format!(
+                "{} WHERE tl.user_id = $1 AND tl.date <= $2 ORDER BY tl.date DESC, tl.created_at DESC",
+                Self::base_query()
+            ),
+            (None, None) => format!(
+                "{} WHERE tl.user_id = $1 ORDER BY tl.date DESC, tl.created_at DESC",
+                Self::base_query()
+            ),
+        };
+
+        let rows = match (start_date, end_date) {
+            (Some(s), Some(e)) => {
+                sqlx::query_as::<_, TimeLogRow>(&query)
+                    .bind(user_id)
+                    .bind(s)
+                    .bind(e)
+                    .fetch_all(&self.pool)
+                    .await?
+            }
+            (Some(s), None) => {
+                sqlx::query_as::<_, TimeLogRow>(&query)
+                    .bind(user_id)
+                    .bind(s)
+                    .fetch_all(&self.pool)
+                    .await?
+            }
+            (None, Some(e)) => {
+                sqlx::query_as::<_, TimeLogRow>(&query)
+                    .bind(user_id)
+                    .bind(e)
+                    .fetch_all(&self.pool)
+                    .await?
+            }
+            (None, None) => {
+                sqlx::query_as::<_, TimeLogRow>(&query)
+                    .bind(user_id)
+                    .fetch_all(&self.pool)
+                    .await?
+            }
+        };
+
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    async fn find_by_task(&self, task_id: Uuid) -> Result<Vec<TimeLog>, DomainError> {
+        let query = format!(
+            "{} WHERE tl.task_id = $1 ORDER BY tl.date DESC, tl.created_at DESC",
+            Self::base_query()
+        );
+        let rows = sqlx::query_as::<_, TimeLogRow>(&query)
+            .bind(task_id)
+            .fetch_all(&self.pool)
+            .await?;
+
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    async fn find_by_date_range(
+        &self,
+        user_id: Uuid,
+        start_date: NaiveDate,
+        end_date: NaiveDate,
+    ) -> Result<Vec<TimeLog>, DomainError> {
+        let query = format!(
+            "{} WHERE tl.user_id = $1 AND tl.date >= $2 AND tl.date <= $3 ORDER BY tl.date DESC, tl.created_at DESC",
+            Self::base_query()
+        );
+        let rows = sqlx::query_as::<_, TimeLogRow>(&query)
+            .bind(user_id)
+            .bind(start_date)
+            .bind(end_date)
+            .fetch_all(&self.pool)
+            .await?;
+
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    async fn create(&self, time_log: &TimeLog) -> Result<TimeLog, DomainError> {
+        sqlx::query(
+            r#"
+            INSERT INTO time_logs (id, task_id, user_id, hours, date, description, created_at, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            "#,
+        )
+        .bind(time_log.id)
+        .bind(time_log.task_id)
+        .bind(time_log.user_id)
+        .bind(time_log.hours)
+        .bind(time_log.date)
+        .bind(&time_log.description)
+        .bind(time_log.created_at)
+        .bind(time_log.updated_at)
+        .execute(&self.pool)
+        .await?;
+
+        // Fetch the created time log with joined data
+        self.find_by_id(time_log.id)
+            .await?
+            .ok_or_else(|| DomainError::NotFound("Time log not found after creation".into()))
+    }
+
+    async fn update(&self, time_log: &TimeLog) -> Result<TimeLog, DomainError> {
+        sqlx::query(
+            r#"
+            UPDATE time_logs
+            SET hours = $1, date = $2, description = $3, updated_at = NOW()
+            WHERE id = $4
+            "#,
+        )
+        .bind(time_log.hours)
+        .bind(time_log.date)
+        .bind(&time_log.description)
+        .bind(time_log.id)
+        .execute(&self.pool)
+        .await?;
+
+        self.find_by_id(time_log.id)
+            .await?
+            .ok_or_else(|| DomainError::NotFound("Time log not found after update".into()))
+    }
+
+    async fn delete(&self, id: Uuid) -> Result<(), DomainError> {
+        sqlx::query("DELETE FROM time_logs WHERE id = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(())
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -15,13 +15,13 @@ mod infrastructure;
 mod presentation;
 mod shared;
 
-use application::services::{ActivityAppService, AuthAppService, ProjectAppService, TaskAppService, TeamAppService};
+use application::services::{ActivityAppService, AuthAppService, ProjectAppService, TaskAppService, TeamAppService, TimeLogAppService};
 use infrastructure::{
     config::AppConfig,
     database,
-    persistence::{PgActivityLogRepository, PgProjectRepository, PgTaskRepository, PgTeamRepository, PgUserRepository},
+    persistence::{PgActivityLogRepository, PgProjectRepository, PgTaskRepository, PgTeamRepository, PgTimeLogRepository, PgUserRepository},
 };
-use presentation::handlers::{activity_handler, auth_handler, project_handler, task_handler, team_handler};
+use presentation::handlers::{activity_handler, auth_handler, project_handler, task_handler, team_handler, time_log_handler};
 use presentation::middleware::auth_middleware;
 
 #[tokio::main]
@@ -49,6 +49,7 @@ async fn main() {
     let task_repository = Arc::new(PgTaskRepository::new(pool.clone()));
     let team_repository = Arc::new(PgTeamRepository::new(pool.clone()));
     let activity_repository = Arc::new(PgActivityLogRepository::new(pool.clone()));
+    let time_log_repository = Arc::new(PgTimeLogRepository::new(pool.clone()));
 
     // Create application services
     let auth_service = Arc::new(AuthAppService::new(
@@ -60,6 +61,7 @@ async fn main() {
     let task_service = Arc::new(TaskAppService::new(task_repository));
     let team_service = Arc::new(TeamAppService::new(team_repository));
     let activity_service = Arc::new(ActivityAppService::new(activity_repository));
+    let time_log_service = Arc::new(TimeLogAppService::new(time_log_repository));
 
     // Rate limiting configuration (100 requests per minute per IP)
     let governor_conf = Arc::new(
@@ -103,7 +105,7 @@ async fn main() {
         .route("/health", get(health_check))
         .nest(
             "/api/v1",
-            api_routes(auth_service, project_service, task_service, team_service, activity_service),
+            api_routes(auth_service, project_service, task_service, team_service, activity_service, time_log_service),
         )
         .layer(cors)
         .layer(rate_limit_layer)
@@ -128,6 +130,7 @@ fn api_routes(
     task_service: Arc<TaskAppService>,
     team_service: Arc<TeamAppService>,
     activity_service: Arc<ActivityAppService>,
+    time_log_service: Arc<TimeLogAppService>,
 ) -> Router {
     // Public auth routes (no authentication required)
     let public_auth_routes = Router::new()
@@ -185,10 +188,23 @@ fn api_routes(
         .layer(middleware::from_fn(auth_middleware))
         .with_state(activity_service);
 
+    // Protected time log routes
+    let time_log_routes = Router::new()
+        .route("/time-logs", get(time_log_handler::list_my_time_logs))
+        .route("/time-logs", post(time_log_handler::create_time_log))
+        .route("/time-logs/{id}", get(time_log_handler::get_time_log))
+        .route("/time-logs/{id}", put(time_log_handler::update_time_log))
+        .route("/time-logs/{id}", delete(time_log_handler::delete_time_log))
+        .route("/tasks/{task_id}/time-logs", get(time_log_handler::list_task_time_logs))
+        .route("/users/{user_id}/time-logs", get(time_log_handler::list_user_time_logs))
+        .layer(middleware::from_fn(auth_middleware))
+        .with_state(time_log_service);
+
     Router::new()
         .merge(public_auth_routes)
         .merge(project_routes)
         .merge(task_routes)
         .merge(team_routes)
         .merge(activity_routes)
+        .merge(time_log_routes)
 }

--- a/backend/src/presentation/handlers/mod.rs
+++ b/backend/src/presentation/handlers/mod.rs
@@ -3,3 +3,4 @@ pub mod auth_handler;
 pub mod project_handler;
 pub mod task_handler;
 pub mod team_handler;
+pub mod time_log_handler;

--- a/backend/src/presentation/handlers/time_log_handler.rs
+++ b/backend/src/presentation/handlers/time_log_handler.rs
@@ -1,0 +1,119 @@
+use axum::{
+    extract::{Path, Query, State},
+    Extension,
+    Json,
+};
+use chrono::NaiveDate;
+use serde::Deserialize;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::application::services::{TimeLogAppService, CreateTimeLogDto, UpdateTimeLogDto};
+use crate::domain::entities::TimeLog;
+use crate::presentation::dto::ApiResponse;
+use crate::presentation::middleware::AuthUser;
+use crate::shared::DomainError;
+
+#[derive(Debug, Deserialize)]
+pub struct ListTimeLogsQuery {
+    pub start_date: Option<NaiveDate>,
+    pub end_date: Option<NaiveDate>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateTimeLogRequest {
+    pub task_id: Uuid,
+    pub hours: f32,
+    pub date: NaiveDate,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateTimeLogRequest {
+    pub hours: Option<f32>,
+    pub date: Option<NaiveDate>,
+    pub description: Option<String>,
+}
+
+/// GET /time-logs - List current user's time logs
+pub async fn list_my_time_logs(
+    State(service): State<Arc<TimeLogAppService>>,
+    Extension(auth_user): Extension<AuthUser>,
+    Query(params): Query<ListTimeLogsQuery>,
+) -> Result<Json<ApiResponse<Vec<TimeLog>>>, DomainError> {
+    let time_logs = service.get_user_time_logs(auth_user.id, params.start_date, params.end_date).await?;
+    Ok(Json(ApiResponse::success(time_logs)))
+}
+
+/// GET /time-logs/:id - Get single time log
+pub async fn get_time_log(
+    State(service): State<Arc<TimeLogAppService>>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<ApiResponse<TimeLog>>, DomainError> {
+    let time_log = service.get_time_log(id)
+        .await?
+        .ok_or_else(|| DomainError::NotFound(format!("Time log {} not found", id)))?;
+    Ok(Json(ApiResponse::success(time_log)))
+}
+
+/// GET /tasks/:task_id/time-logs - List time logs for a task
+pub async fn list_task_time_logs(
+    State(service): State<Arc<TimeLogAppService>>,
+    Path(task_id): Path<Uuid>,
+) -> Result<Json<ApiResponse<Vec<TimeLog>>>, DomainError> {
+    let time_logs = service.get_task_time_logs(task_id).await?;
+    Ok(Json(ApiResponse::success(time_logs)))
+}
+
+/// GET /users/:user_id/time-logs - List time logs for a specific user
+pub async fn list_user_time_logs(
+    State(service): State<Arc<TimeLogAppService>>,
+    Path(user_id): Path<Uuid>,
+    Query(params): Query<ListTimeLogsQuery>,
+) -> Result<Json<ApiResponse<Vec<TimeLog>>>, DomainError> {
+    let time_logs = service.get_user_time_logs(user_id, params.start_date, params.end_date).await?;
+    Ok(Json(ApiResponse::success(time_logs)))
+}
+
+/// POST /time-logs - Create a new time log
+pub async fn create_time_log(
+    State(service): State<Arc<TimeLogAppService>>,
+    Extension(auth_user): Extension<AuthUser>,
+    Json(payload): Json<CreateTimeLogRequest>,
+) -> Result<Json<ApiResponse<TimeLog>>, DomainError> {
+    let dto = CreateTimeLogDto {
+        task_id: payload.task_id,
+        user_id: auth_user.id,
+        hours: payload.hours,
+        date: payload.date,
+        description: payload.description,
+    };
+
+    let time_log = service.create_time_log(dto).await?;
+    Ok(Json(ApiResponse::success(time_log)))
+}
+
+/// PUT /time-logs/:id - Update a time log
+pub async fn update_time_log(
+    State(service): State<Arc<TimeLogAppService>>,
+    Path(id): Path<Uuid>,
+    Json(payload): Json<UpdateTimeLogRequest>,
+) -> Result<Json<ApiResponse<TimeLog>>, DomainError> {
+    let dto = UpdateTimeLogDto {
+        hours: payload.hours,
+        date: payload.date,
+        description: payload.description,
+    };
+
+    let time_log = service.update_time_log(id, dto).await?;
+    Ok(Json(ApiResponse::success(time_log)))
+}
+
+/// DELETE /time-logs/:id - Delete a time log
+pub async fn delete_time_log(
+    State(service): State<Arc<TimeLogAppService>>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<ApiResponse<()>>, DomainError> {
+    service.delete_time_log(id).await?;
+    Ok(Json(ApiResponse::success(())))
+}

--- a/frontend/src/app/(dashboard)/timesheet/page.tsx
+++ b/frontend/src/app/(dashboard)/timesheet/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Header } from '@/components/layout/header';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { tasksApi, projectsApi } from '@/lib/api';
+import { tasksApi, projectsApi, timeLogsApi } from '@/lib/api';
 import type { Task, Project, TimeLog } from '@/types';
 import {
   Clock,
@@ -18,43 +18,6 @@ import {
   Calendar,
   Trash2,
 } from 'lucide-react';
-
-// Mock data for demonstration
-const mockTimeLogs: TimeLog[] = [
-  {
-    id: '1',
-    task_id: 't1',
-    user_id: 'u1',
-    task_name: 'Update homepage layout',
-    project_name: 'Website Redesign',
-    description: 'Worked on header section',
-    hours: 2.5,
-    date: new Date().toISOString().split('T')[0],
-    created_at: new Date().toISOString(),
-  },
-  {
-    id: '2',
-    task_id: 't2',
-    user_id: 'u1',
-    task_name: 'Implement login screen',
-    project_name: 'Mobile App',
-    description: 'Form validation',
-    hours: 3,
-    date: new Date().toISOString().split('T')[0],
-    created_at: new Date().toISOString(),
-  },
-  {
-    id: '3',
-    task_id: 't1',
-    user_id: 'u1',
-    task_name: 'Update homepage layout',
-    project_name: 'Website Redesign',
-    description: 'Footer redesign',
-    hours: 1.5,
-    date: new Date(Date.now() - 86400000).toISOString().split('T')[0],
-    created_at: new Date(Date.now() - 86400000).toISOString(),
-  },
-];
 
 function getWeekDates(date: Date): Date[] {
   const week: Date[] = [];
@@ -83,9 +46,10 @@ interface TimeEntryModalProps {
   onSubmit: (entry: { task_id: string; hours: number; date: string; description: string }) => void;
   tasks: Task[];
   selectedDate: string;
+  isSubmitting: boolean;
 }
 
-function TimeEntryModal({ isOpen, onClose, onSubmit, tasks, selectedDate }: TimeEntryModalProps) {
+function TimeEntryModal({ isOpen, onClose, onSubmit, tasks, selectedDate, isSubmitting }: TimeEntryModalProps) {
   const [taskId, setTaskId] = useState('');
   const [hours, setHours] = useState('');
   const [description, setDescription] = useState('');
@@ -101,6 +65,9 @@ function TimeEntryModal({ isOpen, onClose, onSubmit, tasks, selectedDate }: Time
       date: selectedDate,
       description,
     });
+  };
+
+  const handleClose = () => {
     setTaskId('');
     setHours('');
     setDescription('');
@@ -119,6 +86,7 @@ function TimeEntryModal({ isOpen, onClose, onSubmit, tasks, selectedDate }: Time
               onChange={(e) => setTaskId(e.target.value)}
               className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
               required
+              disabled={isSubmitting}
             >
               <option value="">Select task...</option>
               {tasks.map((task) => (
@@ -139,6 +107,7 @@ function TimeEntryModal({ isOpen, onClose, onSubmit, tasks, selectedDate }: Time
               onChange={(e) => setHours(e.target.value)}
               placeholder="e.g. 2.5"
               required
+              disabled={isSubmitting}
             />
           </div>
           <div>
@@ -147,13 +116,16 @@ function TimeEntryModal({ isOpen, onClose, onSubmit, tasks, selectedDate }: Time
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="What did you work on?"
+              disabled={isSubmitting}
             />
           </div>
           <div className="flex gap-2 justify-end">
-            <Button type="button" variant="outline" onClick={onClose}>
+            <Button type="button" variant="outline" onClick={handleClose} disabled={isSubmitting}>
               Cancel
             </Button>
-            <Button type="submit">Save</Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? 'Saving...' : 'Save'}
+            </Button>
           </div>
         </form>
       </div>
@@ -162,10 +134,11 @@ function TimeEntryModal({ isOpen, onClose, onSubmit, tasks, selectedDate }: Time
 }
 
 export default function TimesheetPage() {
-  const [timeLogs, setTimeLogs] = useState<TimeLog[]>(mockTimeLogs);
+  const [timeLogs, setTimeLogs] = useState<TimeLog[]>([]);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [currentWeek, setCurrentWeek] = useState(new Date());
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedDate, setSelectedDate] = useState(formatDate(new Date()));
@@ -174,9 +147,44 @@ export default function TimesheetPage() {
 
   const weekDates = getWeekDates(currentWeek);
 
+  const loadTimeLogs = useCallback(async () => {
+    try {
+      const startDate = formatDate(weekDates[0]);
+      const endDate = formatDate(weekDates[6]);
+      const response = await timeLogsApi.list({ start_date: startDate, end_date: endDate });
+      if (response.data) {
+        setTimeLogs(response.data);
+      }
+    } catch (error) {
+      console.error('Failed to load time logs:', error);
+    }
+  }, [weekDates]);
+
   useEffect(() => {
+    const loadData = async () => {
+      try {
+        const [tasksRes, projectsRes] = await Promise.all([
+          tasksApi.list(),
+          projectsApi.list(),
+        ]);
+
+        if (tasksRes.data) setTasks(tasksRes.data);
+        if (projectsRes.data) setProjects(projectsRes.data);
+      } catch (error) {
+        console.error('Failed to load data:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
     loadData();
   }, []);
+
+  useEffect(() => {
+    if (!loading) {
+      loadTimeLogs();
+    }
+  }, [loading, currentWeek, loadTimeLogs]);
 
   useEffect(() => {
     let interval: NodeJS.Timeout;
@@ -187,22 +195,6 @@ export default function TimesheetPage() {
     }
     return () => clearInterval(interval);
   }, [activeTimer]);
-
-  const loadData = async () => {
-    try {
-      const [tasksRes, projectsRes] = await Promise.all([
-        tasksApi.list(),
-        projectsApi.list(),
-      ]);
-
-      if (tasksRes.data) setTasks(tasksRes.data);
-      if (projectsRes.data) setProjects(projectsRes.data);
-    } catch (error) {
-      console.error('Failed to load data:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const handlePrevWeek = () => {
     const newDate = new Date(currentWeek);
@@ -216,24 +208,38 @@ export default function TimesheetPage() {
     setCurrentWeek(newDate);
   };
 
-  const handleAddEntry = (entry: { task_id: string; hours: number; date: string; description: string }) => {
-    const task = tasks.find((t) => t.id === entry.task_id);
-    const newLog: TimeLog = {
-      id: Date.now().toString(),
-      task_id: entry.task_id,
-      user_id: 'current',
-      task_name: task?.title || 'Unknown Task',
-      project_name: projects.find((p) => p.id === task?.project_id)?.name,
-      description: entry.description,
-      hours: entry.hours,
-      date: entry.date,
-      created_at: new Date().toISOString(),
-    };
-    setTimeLogs([...timeLogs, newLog]);
+  const handleAddEntry = async (entry: { task_id: string; hours: number; date: string; description: string }) => {
+    setIsSubmitting(true);
+    try {
+      const response = await timeLogsApi.create({
+        task_id: entry.task_id,
+        hours: entry.hours,
+        date: entry.date,
+        description: entry.description || undefined,
+      });
+
+      if (response.data) {
+        setTimeLogs([response.data, ...timeLogs]);
+        setIsModalOpen(false);
+      }
+    } catch (error) {
+      console.error('Failed to create time log:', error);
+      alert('Failed to save time entry');
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
-  const handleDeleteEntry = (id: string) => {
-    setTimeLogs(timeLogs.filter((log) => log.id !== id));
+  const handleDeleteEntry = async (id: string) => {
+    if (!confirm('Are you sure you want to delete this entry?')) return;
+
+    try {
+      await timeLogsApi.delete(id);
+      setTimeLogs(timeLogs.filter((log) => log.id !== id));
+    } catch (error) {
+      console.error('Failed to delete time log:', error);
+      alert('Failed to delete time entry');
+    }
   };
 
   const handleStartTimer = (taskId: string) => {
@@ -241,12 +247,12 @@ export default function TimesheetPage() {
     setTimerElapsed(0);
   };
 
-  const handleStopTimer = () => {
+  const handleStopTimer = async () => {
     if (!activeTimer) return;
 
     const hours = Math.round((timerElapsed / 3600) * 4) / 4; // Round to nearest 0.25
     if (hours >= 0.25) {
-      handleAddEntry({
+      await handleAddEntry({
         task_id: activeTimer.taskId,
         hours,
         date: formatDate(new Date()),
@@ -313,7 +319,7 @@ export default function TimesheetPage() {
                       Working on: {tasks.find((t) => t.id === activeTimer.taskId)?.title}
                     </p>
                   </div>
-                  <Button onClick={handleStopTimer} variant="destructive">
+                  <Button onClick={handleStopTimer} variant="danger">
                     <Square className="h-4 w-4 mr-2" />
                     Stop
                   </Button>
@@ -465,6 +471,7 @@ export default function TimesheetPage() {
         onSubmit={handleAddEntry}
         tasks={tasks}
         selectedDate={selectedDate}
+        isSubmitting={isSubmitting}
       />
     </div>
   );

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -3,12 +3,13 @@ import type { HTMLAttributes, ReactNode } from 'react';
 
 interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
   children: ReactNode;
-  variant?: 'default' | 'success' | 'warning' | 'danger' | 'info';
+  variant?: 'default' | 'secondary' | 'success' | 'warning' | 'danger' | 'info';
 }
 
 export function Badge({ className, children, variant = 'default', ...props }: BadgeProps) {
   const variants = {
     default: 'bg-gray-100 text-gray-800',
+    secondary: 'bg-slate-100 text-slate-700',
     success: 'bg-green-100 text-green-800',
     warning: 'bg-yellow-100 text-yellow-800',
     danger: 'bg-red-100 text-red-800',


### PR DESCRIPTION
## Summary
- Add Time Log API backend with full CRUD operations for tracking time spent on tasks
- Update Timesheet frontend page to use real API instead of mock data
- Add weekly timesheet view with navigation between weeks
- Add quick timer functionality for time tracking
- Add secondary variant to Badge component

## Backend Changes
- `TimeLog` entity with task_id, user_id, hours, date, and description fields
- `TimeLogRepository` trait with async CRUD operations
- `PgTimeLogRepository` PostgreSQL implementation using SQLx
- `TimeLogAppService` for business logic layer
- REST endpoints: GET/POST `/time-logs`, GET/PUT/DELETE `/time-logs/{id}`, GET `/tasks/{task_id}/time-logs`, GET `/users/{user_id}/time-logs`

## Frontend Changes
- Timesheet page connected to real timeLogsApi
- Weekly view showing hours per day with totals
- Quick timer with start/stop functionality
- Manual time entry modal
- Badge component updated with secondary variant

## Test plan
- [ ] Verify time log creation via API
- [ ] Test weekly navigation and totals calculation
- [ ] Test timer start/stop and automatic time logging
- [ ] Verify time entry deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)