### PR TITLE
feat: implement Activity Logs API endpoint

### DIFF
--- a/backend/src/application/services/activity_app_service.rs
+++ b/backend/src/application/services/activity_app_service.rs
@@ -1,0 +1,36 @@
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::domain::entities::ActivityLogWithDetails;
+use crate::domain::repositories::ActivityLogRepository;
+use crate::shared::DomainError;
+
+pub struct ActivityAppService {
+    activity_repository: Arc<dyn ActivityLogRepository>,
+}
+
+impl ActivityAppService {
+    pub fn new(activity_repository: Arc<dyn ActivityLogRepository>) -> Self {
+        Self { activity_repository }
+    }
+
+    pub async fn list_activities(&self, limit: Option<i64>, offset: Option<i64>) -> Result<Vec<ActivityLogWithDetails>, DomainError> {
+        let limit = limit.unwrap_or(50).min(100);
+        let offset = offset.unwrap_or(0);
+        self.activity_repository.find_all(limit, offset).await
+    }
+
+    pub async fn get_activities_by_project(&self, project_id: Uuid, limit: Option<i64>) -> Result<Vec<ActivityLogWithDetails>, DomainError> {
+        let limit = limit.unwrap_or(50).min(100);
+        self.activity_repository.find_by_project(project_id, limit).await
+    }
+
+    pub async fn get_activities_by_user(&self, user_id: Uuid, limit: Option<i64>) -> Result<Vec<ActivityLogWithDetails>, DomainError> {
+        let limit = limit.unwrap_or(50).min(100);
+        self.activity_repository.find_by_user(user_id, limit).await
+    }
+
+    pub async fn count_activities(&self) -> Result<i64, DomainError> {
+        self.activity_repository.count().await
+    }
+}

--- a/backend/src/application/services/mod.rs
+++ b/backend/src/application/services/mod.rs
@@ -1,8 +1,10 @@
+mod activity_app_service;
 mod auth_app_service;
 mod project_app_service;
 mod task_app_service;
 mod team_app_service;
 
+pub use activity_app_service::ActivityAppService;
 pub use auth_app_service::{AuthAppService, AuthResponse, Claims};
 pub use project_app_service::ProjectAppService;
 pub use task_app_service::TaskAppService;

--- a/backend/src/domain/entities/activity_log.rs
+++ b/backend/src/domain/entities/activity_log.rs
@@ -1,0 +1,52 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActivityLog {
+    pub id: Uuid,
+    pub user_id: Option<Uuid>,
+    pub project_id: Option<Uuid>,
+    pub action: String,
+    pub entity_type: String,
+    pub entity_id: Uuid,
+    pub details: Option<JsonValue>,
+    pub created_at: DateTime<Utc>,
+}
+
+impl ActivityLog {
+    pub fn new(
+        user_id: Option<Uuid>,
+        project_id: Option<Uuid>,
+        action: String,
+        entity_type: String,
+        entity_id: Uuid,
+        details: Option<JsonValue>,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            user_id,
+            project_id,
+            action,
+            entity_type,
+            entity_id,
+            details,
+            created_at: Utc::now(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActivityLogWithDetails {
+    pub id: Uuid,
+    pub user_id: Option<Uuid>,
+    pub user_name: Option<String>,
+    pub project_id: Option<Uuid>,
+    pub project_name: Option<String>,
+    pub action: String,
+    pub entity_type: String,
+    pub entity_id: Uuid,
+    pub details: Option<JsonValue>,
+    pub created_at: DateTime<Utc>,
+}

--- a/backend/src/domain/entities/mod.rs
+++ b/backend/src/domain/entities/mod.rs
@@ -1,9 +1,11 @@
+mod activity_log;
 mod milestone;
 mod project;
 mod task;
 mod team;
 mod user;
 
+pub use activity_log::{ActivityLog, ActivityLogWithDetails};
 pub use milestone::Milestone;
 pub use project::{Project, ProjectMember};
 pub use task::{Task, TaskComment};

--- a/backend/src/domain/repositories/activity_log_repository.rs
+++ b/backend/src/domain/repositories/activity_log_repository.rs
@@ -1,0 +1,14 @@
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::domain::entities::{ActivityLog, ActivityLogWithDetails};
+use crate::shared::DomainError;
+
+#[async_trait]
+pub trait ActivityLogRepository: Send + Sync {
+    async fn find_all(&self, limit: i64, offset: i64) -> Result<Vec<ActivityLogWithDetails>, DomainError>;
+    async fn find_by_project(&self, project_id: Uuid, limit: i64) -> Result<Vec<ActivityLogWithDetails>, DomainError>;
+    async fn find_by_user(&self, user_id: Uuid, limit: i64) -> Result<Vec<ActivityLogWithDetails>, DomainError>;
+    async fn create(&self, log: &ActivityLog) -> Result<ActivityLog, DomainError>;
+    async fn count(&self) -> Result<i64, DomainError>;
+}

--- a/backend/src/domain/repositories/mod.rs
+++ b/backend/src/domain/repositories/mod.rs
@@ -1,8 +1,10 @@
+mod activity_log_repository;
 mod project_repository;
 mod task_repository;
 mod team_repository;
 mod user_repository;
 
+pub use activity_log_repository::ActivityLogRepository;
 pub use project_repository::ProjectRepository;
 pub use task_repository::TaskRepository;
 pub use team_repository::TeamRepository;

--- a/backend/src/infrastructure/persistence/mod.rs
+++ b/backend/src/infrastructure/persistence/mod.rs
@@ -1,8 +1,10 @@
+mod pg_activity_log_repository;
 mod pg_project_repository;
 mod pg_task_repository;
 mod pg_team_repository;
 mod pg_user_repository;
 
+pub use pg_activity_log_repository::PgActivityLogRepository;
 pub use pg_project_repository::PgProjectRepository;
 pub use pg_task_repository::PgTaskRepository;
 pub use pg_team_repository::PgTeamRepository;

--- a/backend/src/infrastructure/persistence/pg_activity_log_repository.rs
+++ b/backend/src/infrastructure/persistence/pg_activity_log_repository.rs
@@ -1,0 +1,199 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde_json::Value as JsonValue;
+use sqlx::{FromRow, PgPool};
+use uuid::Uuid;
+
+use crate::domain::entities::{ActivityLog, ActivityLogWithDetails};
+use crate::domain::repositories::ActivityLogRepository;
+use crate::shared::DomainError;
+
+#[derive(Debug, FromRow)]
+struct ActivityLogRow {
+    id: Uuid,
+    user_id: Option<Uuid>,
+    project_id: Option<Uuid>,
+    action: String,
+    entity_type: String,
+    entity_id: Uuid,
+    details: Option<JsonValue>,
+    created_at: DateTime<Utc>,
+}
+
+impl From<ActivityLogRow> for ActivityLog {
+    fn from(row: ActivityLogRow) -> Self {
+        ActivityLog {
+            id: row.id,
+            user_id: row.user_id,
+            project_id: row.project_id,
+            action: row.action,
+            entity_type: row.entity_type,
+            entity_id: row.entity_id,
+            details: row.details,
+            created_at: row.created_at,
+        }
+    }
+}
+
+#[derive(Debug, FromRow)]
+struct ActivityLogWithDetailsRow {
+    id: Uuid,
+    user_id: Option<Uuid>,
+    user_name: Option<String>,
+    project_id: Option<Uuid>,
+    project_name: Option<String>,
+    action: String,
+    entity_type: String,
+    entity_id: Uuid,
+    details: Option<JsonValue>,
+    created_at: DateTime<Utc>,
+}
+
+impl From<ActivityLogWithDetailsRow> for ActivityLogWithDetails {
+    fn from(row: ActivityLogWithDetailsRow) -> Self {
+        ActivityLogWithDetails {
+            id: row.id,
+            user_id: row.user_id,
+            user_name: row.user_name,
+            project_id: row.project_id,
+            project_name: row.project_name,
+            action: row.action,
+            entity_type: row.entity_type,
+            entity_id: row.entity_id,
+            details: row.details,
+            created_at: row.created_at,
+        }
+    }
+}
+
+pub struct PgActivityLogRepository {
+    pool: PgPool,
+}
+
+impl PgActivityLogRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl ActivityLogRepository for PgActivityLogRepository {
+    async fn find_all(&self, limit: i64, offset: i64) -> Result<Vec<ActivityLogWithDetails>, DomainError> {
+        let rows = sqlx::query_as::<_, ActivityLogWithDetailsRow>(
+            r#"
+            SELECT
+                al.id,
+                al.user_id,
+                u.name as user_name,
+                al.project_id,
+                p.name as project_name,
+                al.action,
+                al.entity_type,
+                al.entity_id,
+                al.details,
+                al.created_at
+            FROM activity_logs al
+            LEFT JOIN users u ON al.user_id = u.id
+            LEFT JOIN projects p ON al.project_id = p.id
+            ORDER BY al.created_at DESC
+            LIMIT $1 OFFSET $2
+            "#,
+        )
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    async fn find_by_project(&self, project_id: Uuid, limit: i64) -> Result<Vec<ActivityLogWithDetails>, DomainError> {
+        let rows = sqlx::query_as::<_, ActivityLogWithDetailsRow>(
+            r#"
+            SELECT
+                al.id,
+                al.user_id,
+                u.name as user_name,
+                al.project_id,
+                p.name as project_name,
+                al.action,
+                al.entity_type,
+                al.entity_id,
+                al.details,
+                al.created_at
+            FROM activity_logs al
+            LEFT JOIN users u ON al.user_id = u.id
+            LEFT JOIN projects p ON al.project_id = p.id
+            WHERE al.project_id = $1
+            ORDER BY al.created_at DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(project_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    async fn find_by_user(&self, user_id: Uuid, limit: i64) -> Result<Vec<ActivityLogWithDetails>, DomainError> {
+        let rows = sqlx::query_as::<_, ActivityLogWithDetailsRow>(
+            r#"
+            SELECT
+                al.id,
+                al.user_id,
+                u.name as user_name,
+                al.project_id,
+                p.name as project_name,
+                al.action,
+                al.entity_type,
+                al.entity_id,
+                al.details,
+                al.created_at
+            FROM activity_logs al
+            LEFT JOIN users u ON al.user_id = u.id
+            LEFT JOIN projects p ON al.project_id = p.id
+            WHERE al.user_id = $1
+            ORDER BY al.created_at DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(user_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    async fn create(&self, log: &ActivityLog) -> Result<ActivityLog, DomainError> {
+        let row = sqlx::query_as::<_, ActivityLogRow>(
+            r#"
+            INSERT INTO activity_logs (id, user_id, project_id, action, entity_type, entity_id, details, created_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            RETURNING *
+            "#,
+        )
+        .bind(log.id)
+        .bind(log.user_id)
+        .bind(log.project_id)
+        .bind(&log.action)
+        .bind(&log.entity_type)
+        .bind(log.entity_id)
+        .bind(&log.details)
+        .bind(log.created_at)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row.into())
+    }
+
+    async fn count(&self) -> Result<i64, DomainError> {
+        let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM activity_logs")
+            .fetch_one(&self.pool)
+            .await?;
+
+        Ok(row.0)
+    }
+}

--- a/backend/src/presentation/handlers/activity_handler.rs
+++ b/backend/src/presentation/handlers/activity_handler.rs
@@ -1,0 +1,35 @@
+use axum::{
+    extract::{Query, State},
+    Json,
+};
+use serde::Deserialize;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::application::services::ActivityAppService;
+use crate::domain::entities::ActivityLogWithDetails;
+use crate::presentation::dto::ApiResponse;
+use crate::shared::DomainError;
+
+#[derive(Debug, Deserialize)]
+pub struct ListActivitiesQuery {
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+    pub project_id: Option<Uuid>,
+    pub user_id: Option<Uuid>,
+}
+
+pub async fn list_activities(
+    State(service): State<Arc<ActivityAppService>>,
+    Query(query): Query<ListActivitiesQuery>,
+) -> Result<Json<ApiResponse<Vec<ActivityLogWithDetails>>>, DomainError> {
+    let activities = if let Some(project_id) = query.project_id {
+        service.get_activities_by_project(project_id, query.limit).await?
+    } else if let Some(user_id) = query.user_id {
+        service.get_activities_by_user(user_id, query.limit).await?
+    } else {
+        service.list_activities(query.limit, query.offset).await?
+    };
+
+    Ok(Json(ApiResponse::success(activities)))
+}

--- a/backend/src/presentation/handlers/mod.rs
+++ b/backend/src/presentation/handlers/mod.rs
@@ -1,3 +1,4 @@
+pub mod activity_handler;
 pub mod auth_handler;
 pub mod project_handler;
 pub mod task_handler;


### PR DESCRIPTION
## Summary
- Implement complete Activity Logs API with GET /api/v1/activities endpoint
- Add backend layer: entity, repository, service, and handler following existing patterns
- Support filtering by project_id and user_id query parameters
- Update frontend Activity page to consume real API instead of mock data

## Changes
### Backend
- `activity_log.rs`: ActivityLog and ActivityLogWithDetails entities
- `activity_log_repository.rs`: Repository trait with find_all, find_by_project, find_by_user
- `pg_activity_log_repository.rs`: PostgreSQL implementation with JOINs for user/project names
- `activity_app_service.rs`: Application service with pagination support
- `activity_handler.rs`: Handler with list_activities endpoint

### Frontend
- Updated Activity page to use activityApi.list() instead of mock data
- Added project filter that triggers API call with project_id param

## Test plan
- [ ] Start docker compose and verify GET /api/v1/activities returns 200
- [ ] Test filter by project_id param
- [ ] Verify frontend Activity page loads data from API

Closes #13