### PR TITLE
feat: implement Authorization/RBAC for all endpoints

### DIFF
--- a/backend/src/application/services/project_app_service.rs
+++ b/backend/src/application/services/project_app_service.rs
@@ -15,8 +15,24 @@ impl ProjectAppService {
         Self { project_repository }
     }
 
+    /// List all projects (admin only - use list_accessible_projects for regular users)
     pub async fn list_projects(&self) -> Result<Vec<Project>, DomainError> {
         self.project_repository.find_all().await
+    }
+
+    /// List projects accessible by user (owner OR member)
+    pub async fn list_accessible_projects(&self, user_id: Uuid) -> Result<Vec<Project>, DomainError> {
+        self.project_repository.find_accessible_by_user(user_id).await
+    }
+
+    /// Check if user can access project
+    pub async fn can_user_access(&self, project_id: Uuid, user_id: Uuid) -> Result<bool, DomainError> {
+        self.project_repository.can_user_access(project_id, user_id).await
+    }
+
+    /// Check if user is owner of project
+    pub async fn is_owner(&self, project_id: Uuid, user_id: Uuid) -> Result<bool, DomainError> {
+        self.project_repository.is_owner(project_id, user_id).await
     }
 
     pub async fn get_project(&self, id: Uuid) -> Result<Project, DomainError> {

--- a/backend/src/application/services/task_app_service.rs
+++ b/backend/src/application/services/task_app_service.rs
@@ -19,6 +19,26 @@ impl TaskAppService {
         self.task_repository.find_all().await
     }
 
+    /// List tasks from projects user can access (owner OR member)
+    pub async fn list_accessible_tasks(&self, user_id: Uuid) -> Result<Vec<Task>, DomainError> {
+        self.task_repository.find_accessible_by_user(user_id).await
+    }
+
+    /// Check if user can access task (via project access)
+    pub async fn can_user_access(&self, task_id: Uuid, user_id: Uuid) -> Result<bool, DomainError> {
+        self.task_repository.can_user_access(task_id, user_id).await
+    }
+
+    /// Check if user is owner of the project containing the task
+    pub async fn is_project_owner(&self, task_id: Uuid, user_id: Uuid) -> Result<bool, DomainError> {
+        self.task_repository.is_project_owner(task_id, user_id).await
+    }
+
+    /// Check if user can access project (for create task)
+    pub async fn can_access_project(&self, project_id: Uuid, user_id: Uuid) -> Result<bool, DomainError> {
+        self.task_repository.can_access_project(project_id, user_id).await
+    }
+
     pub async fn get_task(&self, id: Uuid) -> Result<Task, DomainError> {
         self.task_repository
             .find_by_id(id)

--- a/backend/src/application/services/team_app_service.rs
+++ b/backend/src/application/services/team_app_service.rs
@@ -19,6 +19,21 @@ impl TeamAppService {
         self.team_repository.find_all().await
     }
 
+    /// List teams accessible by user (lead OR member)
+    pub async fn list_accessible_teams(&self, user_id: Uuid) -> Result<Vec<Team>, DomainError> {
+        self.team_repository.find_accessible_by_user(user_id).await
+    }
+
+    /// Check if user can access team (is lead OR member)
+    pub async fn can_user_access(&self, team_id: Uuid, user_id: Uuid) -> Result<bool, DomainError> {
+        self.team_repository.can_user_access(team_id, user_id).await
+    }
+
+    /// Check if user is lead of team
+    pub async fn is_lead(&self, team_id: Uuid, user_id: Uuid) -> Result<bool, DomainError> {
+        self.team_repository.is_lead(team_id, user_id).await
+    }
+
     pub async fn get_team(&self, id: Uuid) -> Result<Team, DomainError> {
         self.team_repository
             .find_by_id(id)

--- a/backend/src/domain/repositories/project_repository.rs
+++ b/backend/src/domain/repositories/project_repository.rs
@@ -9,6 +9,12 @@ pub trait ProjectRepository: Send + Sync {
     async fn find_by_id(&self, id: Uuid) -> Result<Option<Project>, DomainError>;
     async fn find_all(&self) -> Result<Vec<Project>, DomainError>;
     async fn find_by_owner(&self, owner_id: Uuid) -> Result<Vec<Project>, DomainError>;
+    /// Find projects accessible by user (owner OR member)
+    async fn find_accessible_by_user(&self, user_id: Uuid) -> Result<Vec<Project>, DomainError>;
+    /// Check if user can access project (is owner OR member)
+    async fn can_user_access(&self, project_id: Uuid, user_id: Uuid) -> Result<bool, DomainError>;
+    /// Check if user is owner of project
+    async fn is_owner(&self, project_id: Uuid, user_id: Uuid) -> Result<bool, DomainError>;
     async fn create(&self, project: &Project) -> Result<Project, DomainError>;
     async fn update(&self, project: &Project) -> Result<Project, DomainError>;
     async fn delete(&self, id: Uuid) -> Result<(), DomainError>;

--- a/backend/src/domain/repositories/task_repository.rs
+++ b/backend/src/domain/repositories/task_repository.rs
@@ -12,6 +12,14 @@ pub trait TaskRepository: Send + Sync {
     async fn find_by_project(&self, project_id: Uuid) -> Result<Vec<Task>, DomainError>;
     async fn find_by_assignee(&self, user_id: Uuid) -> Result<Vec<Task>, DomainError>;
     async fn find_by_status(&self, status: TaskStatus) -> Result<Vec<Task>, DomainError>;
+    /// Find tasks from projects user can access (owner OR member)
+    async fn find_accessible_by_user(&self, user_id: Uuid) -> Result<Vec<Task>, DomainError>;
+    /// Check if user can access task (via project access)
+    async fn can_user_access(&self, task_id: Uuid, user_id: Uuid) -> Result<bool, DomainError>;
+    /// Check if user is owner of the project containing the task
+    async fn is_project_owner(&self, task_id: Uuid, user_id: Uuid) -> Result<bool, DomainError>;
+    /// Check if user can access project (for create task)
+    async fn can_access_project(&self, project_id: Uuid, user_id: Uuid) -> Result<bool, DomainError>;
     async fn create(&self, task: &Task) -> Result<Task, DomainError>;
     async fn update(&self, task: &Task) -> Result<Task, DomainError>;
     async fn delete(&self, id: Uuid) -> Result<(), DomainError>;

--- a/backend/src/domain/repositories/team_repository.rs
+++ b/backend/src/domain/repositories/team_repository.rs
@@ -8,6 +8,12 @@ use crate::shared::DomainError;
 pub trait TeamRepository: Send + Sync {
     async fn find_by_id(&self, id: Uuid) -> Result<Option<Team>, DomainError>;
     async fn find_all(&self) -> Result<Vec<Team>, DomainError>;
+    /// Find teams where user is lead OR member
+    async fn find_accessible_by_user(&self, user_id: Uuid) -> Result<Vec<Team>, DomainError>;
+    /// Check if user can access team (is lead OR member)
+    async fn can_user_access(&self, team_id: Uuid, user_id: Uuid) -> Result<bool, DomainError>;
+    /// Check if user is lead of team
+    async fn is_lead(&self, team_id: Uuid, user_id: Uuid) -> Result<bool, DomainError>;
     async fn create(&self, team: &Team) -> Result<Team, DomainError>;
     async fn update(&self, team: &Team) -> Result<Team, DomainError>;
     async fn delete(&self, id: Uuid) -> Result<(), DomainError>;

--- a/backend/src/presentation/handlers/project_handler.rs
+++ b/backend/src/presentation/handlers/project_handler.rs
@@ -8,21 +8,35 @@ use uuid::Uuid;
 use crate::application::commands::{CreateProjectCommand, UpdateProjectCommand};
 use crate::application::services::ProjectAppService;
 use crate::domain::entities::{Milestone, Project, Task};
+use crate::domain::value_objects::UserRole;
 use crate::presentation::dto::ApiResponse;
 use crate::presentation::middleware::AuthUser;
 use crate::shared::DomainError;
 
 pub async fn list_projects(
     State(service): State<Arc<ProjectAppService>>,
+    Extension(auth_user): Extension<AuthUser>,
 ) -> Result<Json<ApiResponse<Vec<Project>>>, DomainError> {
-    let projects = service.list_projects().await?;
+    // Admin can see all projects, others only see accessible ones
+    let projects = if auth_user.role == UserRole::Admin {
+        service.list_projects().await?
+    } else {
+        service.list_accessible_projects(auth_user.id).await?
+    };
     Ok(Json(ApiResponse::success(projects)))
 }
 
 pub async fn get_project(
     State(service): State<Arc<ProjectAppService>>,
+    Extension(auth_user): Extension<AuthUser>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ApiResponse<Project>>, DomainError> {
+    // Check access permission (admin can access all)
+    if auth_user.role != UserRole::Admin {
+        if !service.can_user_access(id, auth_user.id).await? {
+            return Err(DomainError::Forbidden("You don't have access to this project".into()));
+        }
+    }
     let project = service.get_project(id).await?;
     Ok(Json(ApiResponse::success(project)))
 }
@@ -47,6 +61,13 @@ pub async fn update_project(
     Path(id): Path<Uuid>,
     Json(cmd): Json<UpdateProjectCommand>,
 ) -> Result<Json<ApiResponse<Project>>, DomainError> {
+    // Only owner or admin can update project
+    if auth_user.role != UserRole::Admin {
+        if !service.is_owner(id, auth_user.id).await? {
+            return Err(DomainError::Forbidden("Only project owner can update this project".into()));
+        }
+    }
+
     tracing::info!(
         user_id = %auth_user.id,
         project_id = %id,
@@ -61,6 +82,13 @@ pub async fn delete_project(
     Extension(auth_user): Extension<AuthUser>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ApiResponse<()>>, DomainError> {
+    // Only owner or admin can delete project
+    if auth_user.role != UserRole::Admin {
+        if !service.is_owner(id, auth_user.id).await? {
+            return Err(DomainError::Forbidden("Only project owner can delete this project".into()));
+        }
+    }
+
     tracing::info!(
         user_id = %auth_user.id,
         project_id = %id,
@@ -72,16 +100,30 @@ pub async fn delete_project(
 
 pub async fn get_project_tasks(
     State(service): State<Arc<ProjectAppService>>,
+    Extension(auth_user): Extension<AuthUser>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ApiResponse<Vec<Task>>>, DomainError> {
+    // Check access permission (admin can access all)
+    if auth_user.role != UserRole::Admin {
+        if !service.can_user_access(id, auth_user.id).await? {
+            return Err(DomainError::Forbidden("You don't have access to this project".into()));
+        }
+    }
     let tasks = service.get_project_tasks(id).await?;
     Ok(Json(ApiResponse::success(tasks)))
 }
 
 pub async fn get_project_milestones(
     State(service): State<Arc<ProjectAppService>>,
+    Extension(auth_user): Extension<AuthUser>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ApiResponse<Vec<Milestone>>>, DomainError> {
+    // Check access permission (admin can access all)
+    if auth_user.role != UserRole::Admin {
+        if !service.can_user_access(id, auth_user.id).await? {
+            return Err(DomainError::Forbidden("You don't have access to this project".into()));
+        }
+    }
     let milestones = service.get_project_milestones(id).await?;
     Ok(Json(ApiResponse::success(milestones)))
 }

--- a/backend/src/presentation/handlers/task_handler.rs
+++ b/backend/src/presentation/handlers/task_handler.rs
@@ -8,21 +8,35 @@ use uuid::Uuid;
 use crate::application::commands::{CreateTaskCommand, UpdateTaskCommand};
 use crate::application::services::TaskAppService;
 use crate::domain::entities::Task;
+use crate::domain::value_objects::UserRole;
 use crate::presentation::dto::ApiResponse;
 use crate::presentation::middleware::AuthUser;
 use crate::shared::DomainError;
 
 pub async fn list_tasks(
     State(service): State<Arc<TaskAppService>>,
+    Extension(auth_user): Extension<AuthUser>,
 ) -> Result<Json<ApiResponse<Vec<Task>>>, DomainError> {
-    let tasks = service.list_tasks().await?;
+    // Admin can see all tasks, others only see tasks from accessible projects
+    let tasks = if auth_user.role == UserRole::Admin {
+        service.list_tasks().await?
+    } else {
+        service.list_accessible_tasks(auth_user.id).await?
+    };
     Ok(Json(ApiResponse::success(tasks)))
 }
 
 pub async fn get_task(
     State(service): State<Arc<TaskAppService>>,
+    Extension(auth_user): Extension<AuthUser>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ApiResponse<Task>>, DomainError> {
+    // Check access permission (admin can access all)
+    if auth_user.role != UserRole::Admin {
+        if !service.can_user_access(id, auth_user.id).await? {
+            return Err(DomainError::Forbidden("You don't have access to this task".into()));
+        }
+    }
     let task = service.get_task(id).await?;
     Ok(Json(ApiResponse::success(task)))
 }
@@ -32,6 +46,13 @@ pub async fn create_task(
     Extension(auth_user): Extension<AuthUser>,
     Json(cmd): Json<CreateTaskCommand>,
 ) -> Result<Json<ApiResponse<Task>>, DomainError> {
+    // Check access to project (admin can access all)
+    if auth_user.role != UserRole::Admin {
+        if !service.can_access_project(cmd.project_id, auth_user.id).await? {
+            return Err(DomainError::Forbidden("You don't have access to this project".into()));
+        }
+    }
+
     tracing::info!(
         user_id = %auth_user.id,
         project_id = %cmd.project_id,
@@ -47,6 +68,13 @@ pub async fn update_task(
     Path(id): Path<Uuid>,
     Json(cmd): Json<UpdateTaskCommand>,
 ) -> Result<Json<ApiResponse<Task>>, DomainError> {
+    // Check access permission (admin can access all)
+    if auth_user.role != UserRole::Admin {
+        if !service.can_user_access(id, auth_user.id).await? {
+            return Err(DomainError::Forbidden("You don't have access to this task".into()));
+        }
+    }
+
     tracing::info!(
         user_id = %auth_user.id,
         task_id = %id,
@@ -61,6 +89,13 @@ pub async fn delete_task(
     Extension(auth_user): Extension<AuthUser>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ApiResponse<()>>, DomainError> {
+    // Only project owner or admin can delete tasks
+    if auth_user.role != UserRole::Admin {
+        if !service.is_project_owner(id, auth_user.id).await? {
+            return Err(DomainError::Forbidden("Only project owner can delete tasks".into()));
+        }
+    }
+
     tracing::info!(
         user_id = %auth_user.id,
         task_id = %id,

--- a/backend/src/presentation/handlers/team_handler.rs
+++ b/backend/src/presentation/handlers/team_handler.rs
@@ -8,21 +8,35 @@ use uuid::Uuid;
 use crate::application::commands::{AddTeamMemberCommand, CreateTeamCommand, UpdateTeamCommand};
 use crate::application::services::TeamAppService;
 use crate::domain::entities::{Team, TeamMember};
+use crate::domain::value_objects::UserRole;
 use crate::presentation::dto::ApiResponse;
 use crate::presentation::middleware::AuthUser;
 use crate::shared::DomainError;
 
 pub async fn list_teams(
     State(service): State<Arc<TeamAppService>>,
+    Extension(auth_user): Extension<AuthUser>,
 ) -> Result<Json<ApiResponse<Vec<Team>>>, DomainError> {
-    let teams = service.list_teams().await?;
+    // Admin can see all teams, others only see accessible ones
+    let teams = if auth_user.role == UserRole::Admin {
+        service.list_teams().await?
+    } else {
+        service.list_accessible_teams(auth_user.id).await?
+    };
     Ok(Json(ApiResponse::success(teams)))
 }
 
 pub async fn get_team(
     State(service): State<Arc<TeamAppService>>,
+    Extension(auth_user): Extension<AuthUser>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ApiResponse<Team>>, DomainError> {
+    // Check access permission (admin can access all)
+    if auth_user.role != UserRole::Admin {
+        if !service.can_user_access(id, auth_user.id).await? {
+            return Err(DomainError::Forbidden("You don't have access to this team".into()));
+        }
+    }
     let team = service.get_team(id).await?;
     Ok(Json(ApiResponse::success(team)))
 }
@@ -46,6 +60,13 @@ pub async fn update_team(
     Path(id): Path<Uuid>,
     Json(cmd): Json<UpdateTeamCommand>,
 ) -> Result<Json<ApiResponse<Team>>, DomainError> {
+    // Only lead or admin can update team
+    if auth_user.role != UserRole::Admin {
+        if !service.is_lead(id, auth_user.id).await? {
+            return Err(DomainError::Forbidden("Only team lead can update this team".into()));
+        }
+    }
+
     tracing::info!(
         user_id = %auth_user.id,
         team_id = %id,
@@ -60,6 +81,13 @@ pub async fn delete_team(
     Extension(auth_user): Extension<AuthUser>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ApiResponse<()>>, DomainError> {
+    // Only lead or admin can delete team
+    if auth_user.role != UserRole::Admin {
+        if !service.is_lead(id, auth_user.id).await? {
+            return Err(DomainError::Forbidden("Only team lead can delete this team".into()));
+        }
+    }
+
     tracing::info!(
         user_id = %auth_user.id,
         team_id = %id,
@@ -71,8 +99,15 @@ pub async fn delete_team(
 
 pub async fn get_team_members(
     State(service): State<Arc<TeamAppService>>,
+    Extension(auth_user): Extension<AuthUser>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ApiResponse<Vec<TeamMember>>>, DomainError> {
+    // Check access permission (admin can access all)
+    if auth_user.role != UserRole::Admin {
+        if !service.can_user_access(id, auth_user.id).await? {
+            return Err(DomainError::Forbidden("You don't have access to this team".into()));
+        }
+    }
     let members = service.get_team_members(id).await?;
     Ok(Json(ApiResponse::success(members)))
 }
@@ -83,6 +118,13 @@ pub async fn add_team_member(
     Path(team_id): Path<Uuid>,
     Json(cmd): Json<AddTeamMemberCommand>,
 ) -> Result<Json<ApiResponse<TeamMember>>, DomainError> {
+    // Only lead or admin can add team members
+    if auth_user.role != UserRole::Admin {
+        if !service.is_lead(team_id, auth_user.id).await? {
+            return Err(DomainError::Forbidden("Only team lead can add members".into()));
+        }
+    }
+
     tracing::info!(
         user_id = %auth_user.id,
         team_id = %team_id,


### PR DESCRIPTION
## Summary
- Implement role-based access control (RBAC) for projects, tasks, and teams
- Users can only access resources they own or are members of
- Admin role bypasses all authorization checks
- Returns 403 Forbidden for unauthorized access attempts

## Authorization Rules
### Projects
- List: Admin sees all, others see owned or member projects
- View/Tasks/Milestones: Owner or member only
- Update/Delete: Owner only

### Tasks
- List: From accessible projects only
- View/Create/Update: Project access required
- Delete: Project owner only

### Teams
- List: Admin sees all, others see lead or member teams
- View/Members: Lead or member only
- Update/Delete/Add Members: Lead only

## Changes
- Add authorization methods to repositories (find_accessible_by_user, can_user_access, is_owner/is_lead)
- Add corresponding service layer methods
- Add authorization checks in all handlers

## Test Plan
- [ ] Verify admin can access all resources
- [ ] Verify non-admin users can only access owned/member resources
- [ ] Verify 403 Forbidden returned for unauthorized access
- [ ] Verify project owner can update/delete project
- [ ] Verify team lead can manage team members

Closes #15